### PR TITLE
ignore empty href attributes for interoperatibility with django-summernote

### DIFF
--- a/jquery.pjaxr.js
+++ b/jquery.pjaxr.js
@@ -62,12 +62,12 @@
             return;
         }
 
+        var url = $.isFunction(link.href) ? link.href() : link.href;
+
         // ignore empty href (and link tags without href attribute)
-        if (link.href === "") {
+        if (url === "") {
             return;
         }
-
-        var url = $.isFunction(link.href) ? link.href() : link.href;
 
         var xhr_url = url;
         if (xhr_url.indexOf('pjaxr') == -1) {


### PR DESCRIPTION
the javascript generated html code from django-summernote contains link tags without href attribute. i think this can be a general problem with javascript generated html that you integrate from third parties, so workaround this in pjaxr seems to be the right place.
